### PR TITLE
Added an accelerator that acts as a window visibility toggle.

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,9 @@ var accelerators = [
     'MediaNextTrack',
     'MediaPreviousTrack',
     'MediaStop',
-    'MediaPlayPause'
+    'MediaPlayPause',
+    'Cmd+Alt+Y',
+    'Super+Alt+Y'
 ];
 
 mb.on('ready', function ready() {

--- a/src/globalShortcuts.js
+++ b/src/globalShortcuts.js
@@ -15,6 +15,10 @@ exports.init = function (wv) {
             case ('MediaPlayPause'):
                 wv.send('playPause');
                 break;
+            case 'Cmd+Alt+Y':
+            case 'Super+Alt+Y':
+                ipcRenderer.send('hideWindow');
+                break;
         }
     });
 };


### PR DESCRIPTION
Pressing Cmd+Alt+Y (Mac) or Super+Alt+Y (Windows) will show or hide the window.

Note: I haven't tested this on Windows (I'm not even sure the program has been tested on Windows), but just in case I made sure to include the Windows variant of the accelerator. 