### PR TITLE
Make window draggable

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,6 +13,7 @@ if (typeof __dirname !== 'undefined') {
 var userPreferences = {
     alwaysOnTop : true,
     windowResize: false,
+    windowDraggable: false,
     windowPosition : 'trayCenter',
     userAgent : 'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.',
     globalShortcuts : true

--- a/index.html
+++ b/index.html
@@ -106,6 +106,18 @@
                     }
                 });
 
+                var AppConfig = require('./config.js');
+                var config = AppConfig.store.userPreferences;
+                if (config.windowDraggable) {
+                    var body = document.querySelector('body');
+                    body.setAttribute('style',
+                        `
+                            -webkit-app-region: drag;
+                            -webkit-user-select: none;
+                        `
+                    );
+                }
+
                 setTimeout(function () {
                     (function (i, s, o, g, r, a, m) {
                         i['GoogleAnalyticsObject'] = r;

--- a/main.js
+++ b/main.js
@@ -71,7 +71,10 @@ mb.on('ready', function ready() {
     });
 
     mb.tray.on('right-click', toggleWindow);
-    registerGlobalShortcuts();
+
+    if (config.globalShortcuts) {
+        registerGlobalShortcuts();
+    }
 
 });
 

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -12,6 +12,7 @@
     var groups = [
         'alwaysOnTop',
         'windowResize',
+        'windowDraggable',
         'windowPosition',
         'externalLinks',
         'globalShortcuts'

--- a/views/preferences.html
+++ b/views/preferences.html
@@ -85,7 +85,7 @@
                         <p class="title is-3">Window draggable<span
                                 class="tag is-danger is-small">Require a restart</span>
                         </p>
-                        <p class="subtitle is-6">Allow you to resize window</p>
+                        <p class="subtitle is-6">Allow you to drag window</p>
 
                     </div>
                     <p class="control">

--- a/views/preferences.html
+++ b/views/preferences.html
@@ -82,6 +82,26 @@
                 </div>
                 <div class="container">
                     <div class="heading">
+                        <p class="title is-3">Window draggable<span
+                                class="tag is-danger is-small">Require a restart</span>
+                        </p>
+                        <p class="subtitle is-6">Allow you to resize window</p>
+
+                    </div>
+                    <p class="control">
+                        <label class="radio">
+                            <input value="yes" type="radio" name="windowDraggable"
+                                   checked>
+                            Yes
+                        </label>
+                        <label class="radio">
+                            <input value="no" type="radio" name="windowDraggable">
+                            No
+                        </label>
+                    </p>
+                </div>
+                <div class="container">
+                    <div class="heading">
                         <p class="title is-3">Window position</p>
                         <p class="subtitle is-6">Choose position from tray</p>
 


### PR DESCRIPTION
Added a feature to drag window. We can also decide if enabled or disabled in preferences.

This pull request includes a small bug fix: Global shortcuts are registered when starting/restarting the app even if they are disabled in preferences.